### PR TITLE
Implement terminate vs disconnect functionality

### DIFF
--- a/src/ansibug/_socket_helper.py
+++ b/src/ansibug/_socket_helper.py
@@ -151,7 +151,7 @@ class SocketHelper:
 
         data = bytes(buffer[:read])
         if log.isEnabledFor(logging.DEBUG):
-            log.debug("Socket %s recv(%d): %s", self.use, n, base64.b64encode(data).decode())
+            log.debug("Socket %s recv(%d): '%s'", self.use, n, base64.b64encode(data).decode())
         return data
 
     def send(
@@ -161,7 +161,7 @@ class SocketHelper:
     ) -> None:
         """Wraps send but ensures all the data is sent."""
         if log.isEnabledFor(logging.DEBUG):
-            log.debug("Socket %s send: %s", self.use, base64.b64encode(data).decode())
+            log.debug("Socket %s send: '%s'", self.use, base64.b64encode(data).decode())
         cancel_token.sendall(self._sock, data)
 
     def shutdown(

--- a/src/ansibug/dap/__init__.py
+++ b/src/ansibug/dap/__init__.py
@@ -39,6 +39,7 @@ from ._requests import (
     StackTraceRequest,
     StepInRequest,
     StepOutRequest,
+    TerminateRequest,
     ThreadsRequest,
     VariablesRequest,
 )
@@ -61,6 +62,7 @@ from ._responses import (
     StackTraceResponse,
     StepInResponse,
     StepOutResponse,
+    TerminateResponse,
     ThreadsResponse,
     VariablesResponse,
 )
@@ -146,6 +148,8 @@ __all__ = [
     "StoppedEvent",
     "StoppedReason",
     "TerminatedEvent",
+    "TerminateRequest",
+    "TerminateResponse",
     "Thread",
     "ThreadEvent",
     "ThreadsRequest",

--- a/src/ansibug/dap/_messages.py
+++ b/src/ansibug/dap/_messages.py
@@ -34,6 +34,7 @@ class Command(enum.Enum):
     STACK_TRACE = "stackTrace"
     STEP_IN = "stepIn"
     STEP_OUT = "stepOut"
+    TERMINATE = "terminate"
     THREADS = "threads"
     SCOPES = "scopes"
     VARIABLES = "variables"

--- a/src/ansibug/dap/_requests.py
+++ b/src/ansibug/dap/_requests.py
@@ -543,6 +543,23 @@ class StepOutRequest(
 
 
 @dataclasses.dataclass()
+class TerminateRequest(Request, dap={"arguments": {"restart": "restart"}}):
+    """Request to gracefully terminate the debuggee.
+
+    Request sent by the client to gracefully terminate the debuggee. This is
+    sent before a DisconnectRequest as a second attempt if the terminate didn't
+    occur.
+
+    Args:
+        restart: The request is part of a restart sequence.
+    """
+
+    command = Command.TERMINATE
+
+    restart: bool = False
+
+
+@dataclasses.dataclass()
 class ThreadsRequest(Request):
     """Request to retrieve a list of all thread.
 

--- a/src/ansibug/dap/_responses.py
+++ b/src/ansibug/dap/_responses.py
@@ -238,6 +238,13 @@ class StepOutResponse(Response):
 
 
 @dataclasses.dataclass()
+class TerminateResponse(Response):
+    """Response to a TerminateRequest."""
+
+    command = Command.TERMINATE
+
+
+@dataclasses.dataclass()
 class ThreadsResponse(Response, dap={"body": {"threads": "threads"}}):
     """Response to a ThreadsRequest.
 

--- a/src/ansibug/dap/_types.py
+++ b/src/ansibug/dap/_types.py
@@ -74,6 +74,9 @@ class Capabilities(
         "supportsGotoTargetsRequest": "supports_goto_targets_request",
         "supportsStepInTargetsRequest": "supports_step_in_targets_request",
         "supportsCompletionsRequest": "supports_completions_request",
+        "supportTerminateDebuggee": "supports_terminate_debuggee",
+        "supportSuspendDebuggee": "supports_suspend_debuggee",
+        "supportsTerminateRequest": "supports_terminate_request",
         "supportsClipboardContext": "supports_clipboard_context",
     },
 ):
@@ -103,6 +106,12 @@ class Capabilities(
             StepInTargetsRequest.
         supports_completions_request: The debug adapter supports the
             CompletionsRequest.
+        supports_terminate_debuggee: The debug adapter supports the
+            terminate_debuggee` attribute on the DisconnectRequest.
+        supports_suspend_debuggee: The debug adapter supports the
+            suspend_debuggee attribute on the DisconnectRequest.
+        supports_terminate_request: The debug adapter supports the
+            TerminateRequest.
         supports_clipboard_context: The debug adapter supports the clipboard
             context value in the evaluate request.
     """
@@ -127,14 +136,14 @@ class Capabilities(
     # supports_exception_options
     # supports_value_formatting_options
     # supports_exception_info_request
-    # support_terminate_debuggee
-    # support_suspend_debuggee
+    supports_terminate_debuggee: bool = False
+    supports_suspend_debuggee: bool = False
     # supports_delayed_stack_trace_loading
     # supports_loaded_sources_request
     # supports_log_points
     # supports_terminate_threads_request
     # supports_set_expression
-    # supports_terminate_request
+    supports_terminate_request: bool = False
     # supports_data_breakpoints
     # supports_read_memory_request
     # supports_write_memory_request

--- a/tests/integration/test_attach.py
+++ b/tests/integration/test_attach.py
@@ -263,6 +263,178 @@ def test_run_with_listen_no_client(
         raise Exception(f"Playbook failed {actual.returncode}\nSTDOUT: {actual.stdout}\nSTDERR: {actual.stderr}")
 
 
+def test_attach_with_disconnect(
+    dap_client: DAPClient,
+    tmp_path: pathlib.Path,
+) -> None:
+    playbook = tmp_path / "main.yml"
+    playbook.write_text(
+        r"""
+- hosts: localhost
+  gather_facts: false
+  tasks:
+  - name: ping 1
+    ping:
+
+  - name: ping 2
+    ping:
+
+  - name: ping 3
+    ping:
+"""
+    )
+
+    proc = dap_client.attach(playbook, playbook_dir=tmp_path)
+
+    bp_resp = dap_client.send(
+        dap.SetBreakpointsRequest(
+            source=dap.Source(
+                name="main.yml",
+                path=str(playbook.absolute()),
+            ),
+            lines=[8],
+            breakpoints=[dap.SourceBreakpoint(line=8)],
+            source_modified=False,
+        ),
+        dap.SetBreakpointsResponse,
+    )
+    assert len(bp_resp.breakpoints) == 1
+
+    dap_client.send(dap.ConfigurationDoneRequest(), dap.ConfigurationDoneResponse)
+    dap_client.wait_for_message(dap.ThreadEvent)
+
+    dap_client.wait_for_message(dap.StoppedEvent)
+    dap_client.send(dap.DisconnectRequest(terminate_debuggee=False), dap.DisconnectResponse)
+
+    play_out = proc.communicate()
+    if rc := proc.returncode:
+        raise Exception(f"Playbook failed {rc}\nSTDOUT: {play_out[0].decode()}\nSTDERR: {play_out[1].decode()}")
+
+    assert "ok=3" in play_out[0].decode()
+    assert "Unknown error in Debuggee send thread" not in play_out[1].decode()
+
+
+def test_attach_with_terminate(
+    dap_client: DAPClient,
+    tmp_path: pathlib.Path,
+) -> None:
+    playbook = tmp_path / "main.yml"
+    playbook.write_text(
+        r"""
+- hosts: localhost
+  gather_facts: false
+  tasks:
+  - name: ping 1
+    ping:
+
+  - name: ping 2
+    ping:
+
+  - name: ping 3
+    ping:
+"""
+    )
+
+    proc = dap_client.attach(playbook, playbook_dir=tmp_path)
+
+    bp_resp = dap_client.send(
+        dap.SetBreakpointsRequest(
+            source=dap.Source(
+                name="main.yml",
+                path=str(playbook.absolute()),
+            ),
+            lines=[8],
+            breakpoints=[dap.SourceBreakpoint(line=8)],
+            source_modified=False,
+        ),
+        dap.SetBreakpointsResponse,
+    )
+    assert len(bp_resp.breakpoints) == 1
+
+    dap_client.send(dap.ConfigurationDoneRequest(), dap.ConfigurationDoneResponse)
+    dap_client.wait_for_message(dap.ThreadEvent)
+
+    dap_client.wait_for_message(dap.StoppedEvent)
+    dap_client.send(dap.TerminateRequest())
+
+    dap_client.wait_for_message(dap.TerminatedEvent)
+
+    play_out = proc.communicate()
+    assert proc.returncode == 2
+    stdout = play_out[0].decode()
+    stderr = play_out[1].decode()
+
+    assert "Debugger has requested the process to terminate" in stdout
+    assert "ok=1" in stdout
+    assert "Unknown error in Debuggee send thread" not in stderr
+
+
+def test_attach_with_terminate_multiple_plays(
+    dap_client: DAPClient,
+    tmp_path: pathlib.Path,
+) -> None:
+    playbook = tmp_path / "main.yml"
+    playbook.write_text(
+        r"""
+- name: play 1
+  hosts: localhost
+  gather_facts: false
+  tasks:
+  - name: ping 1
+    ping:
+
+  - name: ping 2
+    ping:
+
+  - name: ping 3
+    ping:
+
+- name: play 2
+  hosts: localhost
+  gather_facts: false
+  tasks:
+  - name: ping 4
+    ping:
+"""
+    )
+
+    proc = dap_client.attach(playbook, playbook_dir=tmp_path)
+
+    bp_resp = dap_client.send(
+        dap.SetBreakpointsRequest(
+            source=dap.Source(
+                name="main.yml",
+                path=str(playbook.absolute()),
+            ),
+            lines=[9],
+            breakpoints=[dap.SourceBreakpoint(line=9)],
+            source_modified=False,
+        ),
+        dap.SetBreakpointsResponse,
+    )
+    assert len(bp_resp.breakpoints) == 1
+
+    dap_client.send(dap.ConfigurationDoneRequest(), dap.ConfigurationDoneResponse)
+    dap_client.wait_for_message(dap.ThreadEvent)
+
+    dap_client.wait_for_message(dap.StoppedEvent)
+    dap_client.send(dap.TerminateRequest())
+
+    dap_client.wait_for_message(dap.TerminatedEvent)
+
+    play_out = proc.communicate()
+    assert proc.returncode == 2
+    stdout = play_out[0].decode()
+    stderr = play_out[1].decode()
+
+    assert "PLAY [play 1]" in stdout
+    assert "Debugger has requested the process to terminate" in stdout
+    assert "PLAY [play 2]" not in stdout
+    assert "ok=1" in stdout
+
+    assert "Unknown error in Debuggee send thread" not in stderr
+
+
 def test_attach_invalid_pid(
     dap_client: DAPClient,
 ) -> None:

--- a/tests/integration/test_launch.py
+++ b/tests/integration/test_launch.py
@@ -121,3 +121,175 @@ gather_facts: false
 
     proc.communicate()
     assert proc.returncode != 0
+
+
+def test_launch_with_disconnect(
+    dap_client: DAPClient,
+    tmp_path: pathlib.Path,
+) -> None:
+    playbook = tmp_path / "main.yml"
+    playbook.write_text(
+        r"""
+- hosts: localhost
+  gather_facts: false
+  tasks:
+  - name: ping 1
+    ping:
+
+  - name: ping 2
+    ping:
+
+  - name: ping 3
+    ping:
+"""
+    )
+
+    proc = dap_client.launch(playbook, playbook_dir=tmp_path)
+
+    bp_resp = dap_client.send(
+        dap.SetBreakpointsRequest(
+            source=dap.Source(
+                name="main.yml",
+                path=str(playbook.absolute()),
+            ),
+            lines=[8],
+            breakpoints=[dap.SourceBreakpoint(line=8)],
+            source_modified=False,
+        ),
+        dap.SetBreakpointsResponse,
+    )
+    assert len(bp_resp.breakpoints) == 1
+
+    dap_client.send(dap.ConfigurationDoneRequest(), dap.ConfigurationDoneResponse)
+    dap_client.wait_for_message(dap.ThreadEvent)
+
+    dap_client.wait_for_message(dap.StoppedEvent)
+    dap_client.send(dap.DisconnectRequest(terminate_debuggee=False), dap.DisconnectResponse)
+
+    play_out = proc.communicate()
+    if rc := proc.returncode:
+        raise Exception(f"Playbook failed {rc}\nSTDOUT: {play_out[0].decode()}\nSTDERR: {play_out[1].decode()}")
+
+    assert "ok=3" in play_out[0].decode()
+    assert "Unknown error in Debuggee send thread" not in play_out[1].decode()
+
+
+def test_launch_with_terminate(
+    dap_client: DAPClient,
+    tmp_path: pathlib.Path,
+) -> None:
+    playbook = tmp_path / "main.yml"
+    playbook.write_text(
+        r"""
+- hosts: localhost
+  gather_facts: false
+  tasks:
+  - name: ping 1
+    ping:
+
+  - name: ping 2
+    ping:
+
+  - name: ping 3
+    ping:
+"""
+    )
+
+    proc = dap_client.launch(playbook, playbook_dir=tmp_path)
+
+    bp_resp = dap_client.send(
+        dap.SetBreakpointsRequest(
+            source=dap.Source(
+                name="main.yml",
+                path=str(playbook.absolute()),
+            ),
+            lines=[8],
+            breakpoints=[dap.SourceBreakpoint(line=8)],
+            source_modified=False,
+        ),
+        dap.SetBreakpointsResponse,
+    )
+    assert len(bp_resp.breakpoints) == 1
+
+    dap_client.send(dap.ConfigurationDoneRequest(), dap.ConfigurationDoneResponse)
+    dap_client.wait_for_message(dap.ThreadEvent)
+
+    dap_client.wait_for_message(dap.StoppedEvent)
+    dap_client.send(dap.TerminateRequest())
+
+    dap_client.wait_for_message(dap.TerminatedEvent)
+
+    play_out = proc.communicate()
+    assert proc.returncode == 2
+    stdout = play_out[0].decode()
+    stderr = play_out[1].decode()
+
+    assert "Debugger has requested the process to terminate" in stdout
+    assert "ok=1" in stdout
+    assert "Unknown error in Debuggee send thread" not in stderr
+
+
+def test_launch_with_terminate_multiple_plays(
+    dap_client: DAPClient,
+    tmp_path: pathlib.Path,
+) -> None:
+    playbook = tmp_path / "main.yml"
+    playbook.write_text(
+        r"""
+- name: play 1
+  hosts: localhost
+  gather_facts: false
+  tasks:
+  - name: ping 1
+    ping:
+
+  - name: ping 2
+    ping:
+
+  - name: ping 3
+    ping:
+
+- name: play 2
+  hosts: localhost
+  gather_facts: false
+  tasks:
+  - name: ping 4
+    ping:
+"""
+    )
+
+    proc = dap_client.launch(playbook, playbook_dir=tmp_path)
+
+    bp_resp = dap_client.send(
+        dap.SetBreakpointsRequest(
+            source=dap.Source(
+                name="main.yml",
+                path=str(playbook.absolute()),
+            ),
+            lines=[9],
+            breakpoints=[dap.SourceBreakpoint(line=9)],
+            source_modified=False,
+        ),
+        dap.SetBreakpointsResponse,
+    )
+    assert len(bp_resp.breakpoints) == 1
+
+    dap_client.send(dap.ConfigurationDoneRequest(), dap.ConfigurationDoneResponse)
+    dap_client.wait_for_message(dap.ThreadEvent)
+
+    dap_client.wait_for_message(dap.StoppedEvent)
+    dap_client.send(dap.TerminateRequest())
+
+    dap_client.wait_for_message(dap.TerminatedEvent)
+
+    play_out = proc.communicate()
+    assert proc.returncode == 2
+    stdout = play_out[0].decode()
+    stderr = play_out[1].decode()
+
+    assert "PLAY [play 1]" in stdout
+    assert "Debugger has requested the process to terminate" in stdout
+    assert "PLAY [play 2]" not in stdout
+    assert "ok=1" in stdout
+
+    assert "Unknown error in Debuggee send thread" not in stderr

--- a/tests/unit/test_socket_helper.py
+++ b/tests/unit/test_socket_helper.py
@@ -130,7 +130,7 @@ def test_send_with_cancel() -> None:
                 try:
                     # Even though SO_SNDBUF is set to 4 I still need to send a
                     # lot of data to have this become blocking.
-                    s.send(b"\x00" * 131072, cancel_token)
+                    s.send(b"\x00" * 666666, cancel_token)
                 except Exception as e:
                     state["exp"] = e
 
@@ -166,7 +166,7 @@ def test_send_with_broken_pipe() -> None:
                 try:
                     # Even though SO_SNDBUF is set to 4 I still need to send a
                     # lot of data to have this become blocking.
-                    s.send(b"\x00" * 131072, cancel_token)
+                    s.send(b"\x00" * 666666, cancel_token)
                 except Exception as e:
                     state["exp"] = e
 


### PR DESCRIPTION
Adds support for either disconnecting or terminating a debug session. By default a client typically will use the terminate/stop request for a launch session and a disconnect request for an attach session. This implements the handlers for both these types in Ansible and ensures the session is still ended cleanly when either is requested.