### PR TITLE
Fix up default collections_paths lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 0.2.0 - TBD
+## 0.1.2 - TBD
+
++ Fix properly setting `COLLECTIONS_PATHS` for an `ansibug` run when no explicit config value was provided
 
 ## 0.1.1 - 2024-07-08
 

--- a/src/ansibug/_exec_playbook.py
+++ b/src/ansibug/_exec_playbook.py
@@ -180,7 +180,6 @@ def _configure_ansible_env() -> dict[str, str]:
             "ansible",
             "config",
             "dump",
-            "--only-changed",
             "--format",
             "json",
         ],

--- a/src/ansibug/_version.py
+++ b/src/ansibug/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) 2023 Jordan Borean
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-__version__ = "0.2.0"
+__version__ = "0.1.2"


### PR DESCRIPTION
Fixes the logic when getting the collections_paths value. If this setting was not explicitly set then the lookup would have only set the ansibug collections dir and ignored the standard default in Ansible.

Fixes: https://github.com/jborean93/ansibug/issues/26