### PR TITLE
Skip deprecation message

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
 - repo: https://github.com/psf/black
-  rev: 23.9.1
+  rev: 24.10.0
   hooks:
   - id: black
 
 - repo: https://github.com/PyCQA/isort
-  rev: 5.12.0
+  rev: 5.13.2
   hooks:
   - id: isort
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.6.0
+  rev: v1.13.0
   hooks:
   - id: mypy
     additional_dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0 - TBD
+
++ Stop deprecation message about custom strategy plugins introduced in Ansible 2.19
+
 ## 0.2.0 - 2024-11-10
 
 + Officially support Ansible 2.18 and Python 3.13

--- a/src/ansibug/_version.py
+++ b/src/ansibug/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) 2023 Jordan Borean
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/tests/data/ansible_collections/ns/name/plugins/modules/deprecation.py
+++ b/tests/data/ansible_collections/ns/name/plugins/modules/deprecation.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+
+from __future__ import annotations
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main() -> None:
+    module = AnsibleModule(argument_spec={}, supports_check_mode=True)
+    result = {
+        "changed": False,
+    }
+
+    module.deprecate("Test deprecation", version="2.99")
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/data/ansible_collections/ns/name/plugins/modules/ping.py
+++ b/tests/data/ansible_collections/ns/name/plugins/modules/ping.py
@@ -1,62 +1,24 @@
-# -*- coding: utf-8 -*-
-
-# (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
-# (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#!/usr/bin/python
 
 from __future__ import annotations
-
-DOCUMENTATION = """
----
-module: ns.name.ping
-short_description: Ping description
-description:
-- Ping description
-options:
-  data:
-    description:
-    - Data to return for the RV(ping) return value.
-    - If this parameter is set to V(crash), the module will cause an exception.
-    type: str
-    default: pong
-extends_documentation_fragment:
-- ansible.builtin.action_common_attributes
-attributes:
-  check_mode:
-    support: full
-  diff_mode:
-    support: none
-  platform:
-    platforms: posix
-author:
-- Ansible Core Team
-"""
-
-RETURN = """
-ping:
-  description: Value provided with the O(data) parameter.
-  returned: success
-  type: str
-  sample: pong
-"""
 
 from ansible.module_utils.basic import AnsibleModule
 
 
 def main() -> None:
     module = AnsibleModule(
-        argument_spec=dict(
-            data=dict(type="str", default="pong"),
-        ),
+        argument_spec={
+            "data": {"type": "str", "default": "pong"},
+        },
         supports_check_mode=True,
     )
 
     if module.params["data"] == "crash":
         raise Exception("boom")
 
-    result = dict(
-        ping=module.params["data"],
-    )
+    result = {
+        "ping": module.params["data"],
+    }
 
     module.exit_json(**result)
 


### PR DESCRIPTION
Skip emitting the deprecation message about custom strategy plugins added in Ansible 2.19. While strategy plugins are deprecated in that version the removal is open ended and the core team agrees we should introduce a proper API for this tool before we do that removal.