### PR TITLE
Added option for DAP temp dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.0 - TBD
 
 + Added support for restart with a `Launch` configuration, trying to restart an `Attach` configuration will stop the process but fail to re-attach
++ Added `--temp-dir` option for `python -m ansibug dap ...` to control the temporary directory used for storing the Ansible launch script
 + Stop deprecation message about custom strategy plugins introduced in Ansible 2.19
 
 ## 0.2.0 - 2024-11-10

--- a/src/ansibug/__main__.py
+++ b/src/ansibug/__main__.py
@@ -150,6 +150,19 @@ def parse_args(
         help="Start an executable Debug Adapter Protocol process",
     )
     _add_log_args(dap)
+    dap.add_argument(
+        "--temp-dir",
+        action="store",
+        default=None,
+        # default="/tmp/abc",
+        type=_parse_path,
+        help="The temporary directory to use for storing the launch scripts "
+        "used when starting an ansible-playbook process. If not set, the "
+        "temporary directory will be created in the system's temporary "
+        "directory as returned by tempfile.mkstemp(). This directory must "
+        "be writable by the user running the DAP process and not have the "
+        "NOEXEC flag.",
+    )
 
     # Listen
 
@@ -197,7 +210,7 @@ def main() -> None:
     args = parse_args(sys.argv[1:])
 
     if args.action == "dap":
-        start_dap(args.log_file, args.log_level)
+        start_dap(args.log_file, args.log_level, args.temp_dir)
         return
 
     if args.action == "connect":


### PR DESCRIPTION
Adds an option for `python -m ansibug dap --temp-dir ...` which can be used to control the temporary directory used to run the launch script from. This is designed to be used as an extension option and not part of a launch configuration setting.

Fixes: https://github.com/jborean93/ansibug/issues/34