### PR TITLE
Add bugfixes for latest devel changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.3.2 - TBD
 
++ Bugfixes to work with internal changes introduced with the upcoming Ansible 2.20 release
+
 ## 0.3.1 - 2025-07-08
 
 + Added support for Ansible 2.19 which introduced Data Tagging

--- a/src/ansibug/ansible_collections/ansibug/dap/plugins/strategy/debug.py
+++ b/src/ansibug/ansible_collections/ansibug/dap/plugins/strategy/debug.py
@@ -46,7 +46,15 @@ POST_DATATAGGING = False
 try:
     from ansible.errors import AnsibleBrokenConditionalError
     from ansible.template import trust_as_template
-    from ansible.utils.display import _DeferredWarningContext
+
+    # This import was moved in 2.20
+    try:
+        from ansible._internal._display_utils import (
+            DeferredWarningContext as _DeferredWarningContext,
+        )
+    except ImportError:
+        # Used for Ansible 2.19
+        from ansible.utils.display import _DeferredWarningContext
 
     POST_DATATAGGING = True
 except ImportError:


### PR DESCRIPTION
Fixes the deferred warning context now that the location has changed in Ansible 2.20.